### PR TITLE
Add multicast and multi-session UWB examples and helpers

### DIFF
--- a/examples/UWB_Controlee/UWB_Controlee.ino
+++ b/examples/UWB_Controlee/UWB_Controlee.ino
@@ -1,0 +1,76 @@
+#include "StellaUWB.h"
+
+
+/**
+ * this demo shows how to setup the Arduino Stella tag as simple 
+ * Two-Way Ranging Responder/Controlee
+ * It expects a counterpart setup as a Initiator/Controller
+ * 
+ */
+
+
+// handler for ranging notifications
+void rangingHandler(UWBRangingData &rangingData) {
+  Serial.print("GOT RANGING DATA - Type: "  );
+  Serial.println(rangingData.measureType());
+  if(rangingData.measureType()==(uint8_t)uwb::MeasurementType::TWO_WAY)
+  {
+    
+    RangingMeasures twr=rangingData.twoWayRangingMeasure();
+    for(int j=0;j<rangingData.available();j++)
+    {
+
+      if(twr[j].status==0 && twr[j].distance!=0xFFFF)
+      {
+        Serial.print("Distance: ");
+        Serial.println(twr[j].distance);  
+      }
+    }
+   
+  }
+  
+}
+
+void setup() {
+  Serial.begin(115200);
+ 
+  
+  //define the source (this device) and destination MAC addresses, using 2-bytes MACs
+  uint8_t devAddr[]={0x22,0x22};
+  uint8_t destination[]={0x11,0x11};
+  UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT,devAddr);
+  UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT,destination);
+  
+
+  // register the ranging notification handler before starting
+  UWB.registerRangingCallback(rangingHandler);
+  
+  UWB.begin(); //start the UWB stack, use Serial for the log output
+  Serial.println("Starting UWB ...");
+
+  //wait until the stack is initialised
+  while(UWB.state()!=0)
+    delay(10);
+
+  //setup the session
+  Serial.println("Starting session ...");
+  //setup a session with ID 0x11223344, in this case it defines a Two-Way 
+  //Ranging Responder/Controlee
+  
+  UWBRangingControlee myControlee(0x11223344,srcAddr,dstAddr);
+
+
+  //add the session to the session manager, in case you want to manage multiple connections
+  UWBSessionManager.addSession(myControlee);
+
+  //prepare the session applying the default parameters
+  myControlee.init();
+  
+  //start the session
+  myControlee.start();
+}
+
+void loop() {
+
+  delay(1000);
+}

--- a/examples/UWB_MultiSessionTag1/UWB_MultiSessionTag1.ino
+++ b/examples/UWB_MultiSessionTag1/UWB_MultiSessionTag1.ino
@@ -1,0 +1,77 @@
+#include "StellaUWB.h"
+
+/**
+ * Multi-Session Tag 1 Demo
+ * 
+ * This demo shows how to setup the Arduino Stella as Tag 1 that participates
+ * in a multi-session ranging system. This tag connects to the anchor's 
+ * Session 1 (0x111111).
+ * 
+ * Configuration must match the anchor's Session 1:
+ * - Session ID: 0x111111
+ * - Tag MAC: 0x2222
+ * - Anchor MAC: 0x1111
+ * - Preamble Code: 10
+ * 
+ * The anchor can simultaneously track this tag along with other tags on 
+ * different sessions.
+ * 
+ * It expects a counterpart Portenta C33 setup as a Multi-Session Anchor
+ * 
+ */
+
+// handler for ranging notifications
+void rangingHandler(UWBRangingData &rangingData) {
+  Serial.print("GOT RANGING DATA - Type: ");
+  Serial.println(rangingData.measureType());
+  
+  if(rangingData.measureType()==(uint8_t)uwb::MeasurementType::TWO_WAY)
+  {
+    RangingMeasures twr=rangingData.twoWayRangingMeasure();
+    for(int j=0;j<rangingData.available();j++)
+    {
+      if(twr[j].status==0 && twr[j].distance!=0xFFFF)
+      {
+        Serial.print("Distance: ");
+        Serial.println(twr[j].distance);  
+      }
+    }
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  
+  //define the source (this device) and destination MAC addresses, using 2-bytes MACs
+  uint8_t devAddr[]={0x22,0x22};
+  uint8_t destination[]={0x11,0x11};
+  UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT,devAddr);
+  UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT,destination);
+  
+  // register the ranging notification handler before starting
+  UWB.registerRangingCallback(rangingHandler);
+  
+  UWB.begin(); //start the UWB stack, use Serial for the log output
+  Serial.println("Starting UWB ...");
+
+  //wait until the stack is initialised
+  while(UWB.state()!=0)
+    delay(10);
+
+  Serial.println("Starting session ...");
+  //setup a session with ID 0x111111, using preamble code 10
+  UWBMultiSessionTag myTag(0x111111, srcAddr, dstAddr, 10);
+
+  //add the session to the session manager
+  UWBSessionManager.addSession(myTag);
+
+  //prepare the session applying the configured parameters
+  myTag.init();
+  
+  //start the session
+  myTag.start();
+}
+
+void loop() {
+  delay(1000);
+}

--- a/examples/UWB_MulticastResponder/UWB_MulticastResponder.ino
+++ b/examples/UWB_MulticastResponder/UWB_MulticastResponder.ino
@@ -1,0 +1,78 @@
+#include "StellaUWB.h"
+
+/**
+ * TAG (Responder) participates in multicast
+ *
+ * This demo shows how to setup the Arduino Stella TAG as a
+ * Two-Way Ranging RESPONDER/CONTROLEE that participates in a
+ * multicast (one-to-many) session started by a Controller.
+ * It expects a Controller (e.g. Portenta) configured as multicast
+ * initiator, and this Stella TAG joins as one of the controlees.
+ */
+
+
+// handler for ranging notifications
+void rangingHandler(UWBRangingData &rangingData) {
+  Serial.print("GOT RANGING DATA - Type: "  );
+  Serial.println(rangingData.measureType());
+  if(rangingData.measureType()==(uint8_t)uwb::MeasurementType::TWO_WAY)
+  {
+    
+    RangingMeasures twr=rangingData.twoWayRangingMeasure();
+    for(int j=0;j<rangingData.available();j++)
+    {
+
+      if(twr[j].status==0 && twr[j].distance!=0xFFFF)
+      {
+        Serial.print("Distance: ");
+        Serial.println(twr[j].distance);  
+      }
+    }
+   
+  }
+  
+}
+
+void setup() {
+  Serial.begin(115200);
+ 
+  
+  //define the source (this device) and destination MAC addresses, using 2-bytes MACs
+  uint8_t devAddr[]={0x22,0x22};
+  uint8_t destination[]={0x11,0x11};
+  UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT,devAddr);
+  UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT,destination);
+  
+
+  // register the ranging notification handler before starting
+  UWB.registerRangingCallback(rangingHandler);
+  
+  UWB.begin(); //start the UWB stack, use Serial for the log output
+  Serial.println("Starting UWB ...");
+
+  //wait until the stack is initialised
+  while(UWB.state()!=0)
+    delay(10);
+
+  //setup the session
+  Serial.println("Starting TAG (Responder) session in multicast ...");
+  //setup a session with ID 0x11223344, Stella acts as RESPONDER/CONTROLEE
+  //participating in a multicast session initiated by a Controller
+  
+  MulticastResponder mytag(0x11223344,srcAddr,dstAddr);
+
+
+  //add the session to the session manager, in case you want to manage multiple connections
+  UWBSessionManager.addSession(mytag);
+
+  //prepare the session applying the default parameters
+  mytag.init();
+  
+  //start the session
+  mytag.start();
+}
+
+void loop() {
+
+  delay(1000);
+}

--- a/examples/UWB_OneToMany/UWB_OneToMany.ino
+++ b/examples/UWB_OneToMany/UWB_OneToMany.ino
@@ -1,0 +1,73 @@
+#include "StellaUWB.h"
+
+// Handler for ranging notifications 
+void rangingHandler(UWBRangingData &rangingData) {
+	Serial.print("GOT RANGING DATA - Type: ");
+	Serial.println(rangingData.measureType());
+
+	if (rangingData.measureType() == (uint8_t)uwb::MeasurementType::TWO_WAY) {
+		RangingMeasures twr = rangingData.twoWayRangingMeasure();
+		for (int j = 0; j < rangingData.available(); j++) {
+			if (twr[j].status == 0 && twr[j].distance != 0xFFFF) {
+				Serial.print("Distance: ");
+				Serial.println(twr[j].distance);
+			}
+		}
+	}
+}
+
+void setup() {
+	Serial.begin(115200);
+	delay(2000);
+
+	// Define the source (this device) MAC address using 2-byte MAC
+	uint8_t devAddr[] = {0x11, 0x11};
+	UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT, devAddr);
+
+	// Define multiple destination MAC addresses (controlees)
+	uint8_t destination1[] = {0x22, 0x22};
+	uint8_t destination2[] = {0x33, 0x33};
+	uint8_t destination3[] = {0x44, 0x44};
+	uint8_t destination4[] = {0x55, 0x55};
+
+	UWBMacAddress dstAddr1(UWBMacAddress::Size::SHORT, destination1);
+	UWBMacAddress dstAddr2(UWBMacAddress::Size::SHORT, destination2);
+	UWBMacAddress dstAddr3(UWBMacAddress::Size::SHORT, destination3);
+	UWBMacAddress dstAddr4(UWBMacAddress::Size::SHORT, destination4);
+
+	// Create a list of destination addresses
+	UWBMacAddressList dest(UWBMacAddress::Size::SHORT);
+	dest.add(dstAddr1);
+	dest.add(dstAddr2);
+	dest.add(dstAddr3);
+	dest.add(dstAddr4);
+
+	// Register the ranging notification handler before starting
+	UWB.registerRangingCallback(rangingHandler);
+
+	UWB.begin();
+	Serial.println("Starting UWB ...");
+
+	// Wait until the stack is initialised
+	while (UWB.state() != 0) {
+		delay(10);
+	}
+
+	Serial.println("Starting multicast session ...");
+
+	// Set up a multicast session with ID 0x11223344
+	UWBRangingOneToMany myController(0x11223344, srcAddr, dest);
+
+	// Add the session to the session manager, in case multiple connections are needed
+	UWBSessionManager.addSession(myController);
+
+	// Prepare the session applying the default parameters
+	myController.init();
+
+	// Start the session
+	myController.start();
+}
+
+void loop() {
+	delay(1000);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=StellaUWB
-version=1.0.1
+version=1.0.2
 author=Pierpaolo Lento <pierpaolo.lento@truesense.it>
 maintainer=Pierpaolo Lento <pierpaolo.lento@truesense.it>
 sentence=Library for the Arduino Stella UWB Tag.

--- a/src/StellaUWB.h
+++ b/src/StellaUWB.h
@@ -5,6 +5,10 @@
 #include "uwbapps/UWB.hpp"
 #include "uwbapps/UWBUltdoaTag.hpp"
 #include "uwbapps/UWBTracker.hpp"
+#include "uwbapps/UWBRangingControlee.hpp"
+#include "uwbapps/UWBRangingOneToMany.hpp"
+#include "uwbapps/UWBMultiSessionTag.hpp"
+#include "uwbapps/UWBMulticastResponder.hpp"
 #include "uwbapps/NearbySession.hpp"
 #include "uwbapps/NearbySessionManager.hpp"
 

--- a/src/uwbapps/UWBAppParamList.cpp
+++ b/src/uwbapps/UWBAppParamList.cpp
@@ -128,3 +128,7 @@ bool UWBAppParamList::powerId(uint8_t id)
      return addOrUpdateParam(buildScalar(uwb::AppConfigId::TxPowerId, id));
 }
 
+bool UWBAppParamList::destinationMacAddr(UWBMacAddressList addrs)
+{
+    return addOrUpdateParam(buildArray(uwb::AppConfigId::PeerAddress, addrs.getAllData(), addrs.size() * (uint8_t)addrs.macTypeSize()));
+}

--- a/src/uwbapps/UWBAppParamList.hpp
+++ b/src/uwbapps/UWBAppParamList.hpp
@@ -3,6 +3,7 @@
 
 #include "UWBAppParamsList.hpp"
 #include "UWBMacAddress.hpp"
+#include "UWBMacAddressList.hpp"
 
 
 #ifndef __UWBAPPPARAMLIST_HPP__
@@ -392,7 +393,15 @@ public:
      */
     bool destinationMacAddr(UWBMacAddress &addr);
 
-     // WHAT BELOW NEEDS SOME CLARIFICATION
+     /**
+     * @brief Set the Destination Mac Addresses for multicast session
+     *
+     * @param addrs List of destination MAC addresses
+     */
+    bool destinationMacAddr(UWBMacAddressList addrs); 
+     
+
+    // WHAT BELOW NEEDS SOME CLARIFICATION
      //        /**
      //       * @brief Set the Schedule Mode
      //       *

--- a/src/uwbapps/UWBMultiSessionTag.hpp
+++ b/src/uwbapps/UWBMultiSessionTag.hpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Truesense Srl
+
+#ifndef UWBMULTISESSIONTAG_HPP
+#define UWBMULTISESSIONTAG_HPP
+
+#include "hal/uwb_hal.hpp"
+#include "UWB.hpp"
+#include "UWBSession.hpp"
+
+/**
+ * @brief Multi-Session Tag class for participating in multi-anchor systems
+ * 
+ * This class creates a UWB tag that participates in a multi-session ranging
+ * system. The tag connects to an anchor running multiple concurrent sessions,
+ * allowing the anchor to track multiple tags simultaneously.
+ * 
+ * Each tag must be configured with parameters matching its designated session
+ * on the anchor, including unique session ID, MAC addresses, and preamble code.
+ * 
+ */
+class UWBMultiSessionTag : public UWBSession {
+
+public:   
+    /**
+     * @brief Construct a multi-session tag for a specific session
+     * 
+     * @param session_ID Unique identifier matching the anchor's session (e.g., 0x111111)
+     * @param srcAddr MAC address of this tag
+     * @param dstAddr MAC address of the target anchor for this session
+     * @param preambleCode Preamble code (must match anchor's session configuration)
+     */
+    UWBMultiSessionTag(uint32_t session_ID, UWBMacAddress srcAddr, 
+                       UWBMacAddress dstAddr, uint8_t preambleCode = 10)
+    {
+        sessionID(session_ID);
+        sessionType(uwb::SessionType::RANGING);
+            
+        rangingParams.deviceRole(uwb::DeviceRole::INITIATOR);
+        rangingParams.deviceType(uwb::DeviceType::CONTROLLER);
+        rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
+        rangingParams.noOfControlees(1);
+        rangingParams.deviceMacAddr(srcAddr);
+        rangingParams.destinationMacAddr(dstAddr);
+        rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+
+        appParams.frameConfig(uwb::RfFrameConfig::SP3);
+        appParams.slotPerRR(25);
+        appParams.rangingDuration(200);
+        appParams.maxRetries(0);
+        appParams.sfdId(2);
+        appParams.preambleCodeIndex(preambleCode); //must match anchor's session
+        appParams.stsConfig(uwb::StsConfig::StaticSts);
+        appParams.stsSegments(1);
+        appParams.channel(9);
+    }      		
+};
+
+#endif /* UWBMULTISESSIONTAG_HPP */

--- a/src/uwbapps/UWBMulticastResponder.hpp
+++ b/src/uwbapps/UWBMulticastResponder.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Truesense Srl
+
+#ifndef TEST2_HPP
+#define TEST2_HPP
+
+
+#include "hal/uwb_hal.hpp"
+#include "UWB.hpp"
+#include "UWBSession.hpp"
+
+/**
+ * @brief TAG (Responder) participates in multicast
+ *
+ * Helper session for a Stella TAG acting as RESPONDER/CONTROLEE in a
+ * multicast ranging session started by a Controller. The TAG uses 
+ * 2-byte short MAC addresses and DS-TWR in SP3 profile.
+ */
+class  MulticastResponder:public UWBSession {
+
+public:   
+	MulticastResponder(uint32_t session_ID, UWBMacAddress srcAddr, UWBMacAddress dstAddr,uwb::DeviceRole role = uwb::DeviceRole::RESPONDER, uwb::DeviceType deviceType=uwb::DeviceType::CONTROLEE)
+	{
+		sessionID(session_ID);
+		sessionType(uwb::SessionType::RANGING);
+			
+		rangingParams.deviceRole(role);
+		rangingParams.deviceType(deviceType);
+		rangingParams.multiNodeMode(uwb::MultiNodeMode::MULTICAST);
+		rangingParams.noOfControlees(1);
+		rangingParams.deviceMacAddr(srcAddr);
+		rangingParams.destinationMacAddr(dstAddr);
+		rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+
+
+		appParams.frameConfig(uwb::RfFrameConfig::SP3);
+		appParams.slotPerRR(25);
+		appParams.rangingDuration(200);
+		appParams.maxRetries(0);
+		appParams.sfdId(2);
+		appParams.preambleCodeIndex(10);
+		appParams.stsConfig(uwb::StsConfig::StaticSts);
+    	appParams.stsSegments(1);
+	}      		
+};
+
+#endif

--- a/src/uwbapps/UWBRangingOneToMany.hpp
+++ b/src/uwbapps/UWBRangingOneToMany.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Truesense Srl
+
+#ifndef UWBRANGINGONETOMANY
+#define UWBRANGINGONETOMANY
+
+
+#include "UWBSession.hpp"
+#include "UWBMacAddressList.hpp"
+
+/**
+ * @brief One-to-Many ranging Controller helper
+ *
+ * This class configures a ranging session where a single controller (initiator)
+ * performs Two-Way Ranging with multiple controlees in a time-scheduled, secure
+ * SP3 profile. It mirrors the style and defaults of `UWBRangingController` but
+ * targets multicast.
+ */
+class  UWBRangingOneToMany:public UWBSession {
+
+public:
+	// Multicast constructor: accept a list of destination MAC addresses
+	UWBRangingOneToMany(uint32_t session_ID, UWBMacAddress srcAddr, UWBMacAddressList dstAddr)
+	{
+		sessionID(session_ID);
+		sessionType(uwb::SessionType::RANGING);
+		rangingParams.deviceRole(uwb::DeviceRole::INITIATOR);
+		rangingParams.deviceType(uwb::DeviceType::CONTROLLER);
+		rangingParams.multiNodeMode(uwb::MultiNodeMode::MULTICAST);
+		rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+		rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
+		rangingParams.macAddrMode((uint8_t)uwb::MacAddressMode::SHORT);
+		rangingParams.deviceMacAddr(srcAddr);
+		rangingParams.noOfControlees(dstAddr.size());
+		rangingParams.destinationMacAddr(dstAddr);
+
+		appParams.noOfControlees(dstAddr.size());
+		appParams.destinationMacAddr(dstAddr);
+		appParams.frameConfig(uwb::RfFrameConfig::SP3);
+		appParams.slotPerRR(25);
+		appParams.rangingDuration(200);
+		appParams.stsConfig(uwb::StsConfig::StaticSts);
+		appParams.sfdId(2);
+		appParams.preambleCodeIndex(10);
+	}
+};
+
+#endif/* UWBRANGINGONETOMANY */
+


### PR DESCRIPTION
Introduces new example sketches for UWB ranging scenarios: Controlee, Multi-Session Tag, Multicast Responder, and One-to-Many Controller. Adds helper classes (UWBMultiSessionTag, UWBRangingOneToMany, UWBMulticastResponder) for these session types. Updates StellaUWB.h to include new helpers, extends UWBAppParamList to support multiple destination MAC addresses, and bumps library version to 1.0.2.